### PR TITLE
needed to explicitly require stringio

### DIFF
--- a/lib/ppr/ppr_core.rb
+++ b/lib/ppr/ppr_core.rb
@@ -5,6 +5,7 @@
 require "ppr/safer_generator.rb"
 require "ppr/keyword_searcher.rb"
 require 'delegate'
+require 'stringio'
 
 module Ppr
 


### PR DESCRIPTION
This case was giving the error

```
.def GRP :< 3
pr1.group(GRP)
```