### PR TITLE
Eliminate ambiguity between .def, and .assign

### DIFF
--- a/lib/ppr/ppr_core.rb
+++ b/lib/ppr/ppr_core.rb
@@ -5,6 +5,7 @@
 require "ppr/safer_generator.rb"
 require "ppr/keyword_searcher.rb"
 require 'delegate'
+require 'stringio'
 
 module Ppr
 
@@ -197,9 +198,7 @@ class Macro
 
     # Update an exception +message+ to refer the macro invoked at line number
     # +i_number+ and adds a possible macro line +number+.
-    def e_message(message, i_number, number = nil, line_content = nil, wrong_macro = nil)
-        puts "Error near #{line_content}" if line_content
-        puts "Wrong usage of macro near: #{wrong_macro}" if wrong_macro
+    def e_message(message, i_number, number = nil)
         Macro.e_message(@name,message,i_number,number)
     end
 
@@ -568,7 +567,7 @@ class Preprocessor
     end
 
     # Extract a macro definition from a +line+ if there is one.
-    def get_macro_def(line)
+    def get_macro_def(line, return_flag = false)
         line = line.strip
         # Locate and identify the macro keyword.
         macro_type = @macro_keys.find { |mdef| line.start_with?(mdef) }
@@ -624,9 +623,13 @@ class Preprocessor
             # Handle the case of unnamed macros.
             name = ""
         end
+        mtype = nil
+        add_line = nil
         case macro_type
         when @assign then
             macro = Assign.new(name,@number,self,expand: @expand)
+            mtype = ".assign"
+            add_line = ".def " + name + " " + line
         when @loadm then
             macro = Load.new(@number,self,expand: @expand)
             macro.set_locations(@includes)
@@ -637,14 +640,18 @@ class Preprocessor
             macro = If.new(@number,self,expand: @expand)
         else
             macro = Macro.new(name,@number,self,
-                              *arguments,final: final,expand: @expand) 
+                              *arguments,final: final,expand: @expand)
         end
         # Is it a one-line macro?
         unless line.empty? then
             # Yes, adds the content to the macro.
             macro << line
         end
-        return macro
+        if return_flag then
+            return macro, mtype, add_line
+        else
+            return macro
+        end
     end
 
 
@@ -760,6 +767,7 @@ class Preprocessor
 
         # The macro currently being input.
         cur_macro = nil
+        cur_macro1 = nil
 
         # Process the input line by line
         input.each_line.with_index do |line,i|
@@ -816,7 +824,7 @@ class Preprocessor
                 if get_macro_def(line) then
                     # Yet, there is a begining of a macro definition: error
                     raise cur_macro.e_message(
-                        "cannot define a new macro within another macro.",@number, input.each_line.with_index.to_a[i-1][0], line)
+                      "cannot define a new macro within another macro.",@number)
                 end
                 # Is the current macro being closed?
                 if is_endm?(line) then
@@ -831,12 +839,21 @@ class Preprocessor
             else
                 # There in no macro being input.
                 # Check if a new macro definition is present.
-                cur_macro = get_macro_def(line)
+                cur_macro, mtype, new_line = get_macro_def(line, return_flag = true)
                 if cur_macro and !cur_macro.empty? then
                     # This is a one-line macro close it straight await.
                     output << close_macro(cur_macro)
+                    
+                    # define macro when macro is assigned
+                    case mtype
+                    when @assign
+                        # The macro is an assignment.
+                        cur_macro1 = get_macro_def(new_line)
+                        output << close_macro(cur_macro1)
+                    end
                     # The macro ends here.
                     cur_macro = nil
+                    cur_marco1 = nil
                     next # The macro definition is not to be kept in the result
                 end
                 next if cur_macro # A new multi-line macro definition is found,
@@ -852,6 +869,14 @@ class Preprocessor
                 # Write the line to the output.
                 # print ">#{line}"
                 output << line
+                
+                # define macro when macro is assigned
+                case mtype
+                when @assign
+                    # The macro is an assignment.
+                    cur_macro1 = get_macro_def(new_line)
+                    output << close_macro(cur_macro1)
+                end
             end
         end
     end

--- a/lib/ppr/ppr_core.rb
+++ b/lib/ppr/ppr_core.rb
@@ -626,6 +626,8 @@ class Preprocessor
         end
         case macro_type
         when @assign then
+            macro = Macro.new(name,@number,self,
+                *arguments,final: final,expand: @expand)            
             macro = Assign.new(name,@number,self,expand: @expand)
         when @loadm then
             macro = Load.new(@number,self,expand: @expand)

--- a/lib/ppr/ppr_core.rb
+++ b/lib/ppr/ppr_core.rb
@@ -197,7 +197,9 @@ class Macro
 
     # Update an exception +message+ to refer the macro invoked at line number
     # +i_number+ and adds a possible macro line +number+.
-    def e_message(message, i_number, number = nil)
+    def e_message(message, i_number, number = nil, line_content = nil, wrong_macro = nil)
+        puts "Error near #{line_content}" if line_content
+        puts "Wrong usage of macro near: #{wrong_macro}" if wrong_macro
         Macro.e_message(@name,message,i_number,number)
     end
 
@@ -814,7 +816,7 @@ class Preprocessor
                 if get_macro_def(line) then
                     # Yet, there is a begining of a macro definition: error
                     raise cur_macro.e_message(
-                      "cannot define a new macro within another macro.",@number)
+                        "cannot define a new macro within another macro.",@number, input.each_line.with_index.to_a[i-1][0], line)
                 end
                 # Is the current macro being closed?
                 if is_endm?(line) then


### PR DESCRIPTION
Hey @civol, We have been having trouble with the ambiguity between `.def`, and `.assign`. A lot of the time we are making duplicates for both `.def`, and `.assign`. @halmusaibeli has routed `.assign` to also `.def` so that there are no duplicates, and to eliminate the ambiguity as to whether the macro should be `.def`, or `.assign`.

Thanks!